### PR TITLE
Update RGBToString.js

### DIFF
--- a/src/display/color/RGBToString.js
+++ b/src/display/color/RGBToString.js
@@ -27,7 +27,7 @@ var RGBToString = function (r, g, b, a, prefix)
 
     if (prefix === '#')
     {
-        return '#' + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1);
+        return '#' + ((1 << 24) + (r << 16) + (g << 8) + b).toString(16).slice(1, 7);
     }
     else
     {


### PR DESCRIPTION
Prevent adding decimal places behind RGB string with '#' prefix.

This PR
* Fixes a bug

Describe the changes below:

Currently if the r g b arguments to RGBToString have decimal places it may cause the output string to have decimal places, e.g. '#898989.4cccccd'. This change simply cuts off anything after the proper 6 digits.

